### PR TITLE
Show DPS stats

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -772,6 +772,24 @@ function Arena:set_timer_text()
   self.timer_text = Text({{text = '[wavy_mid, yellow[0] ' .. tostring(math.floor(self.time_elapsed)) .. 's', font = pixul_font, alignment = 'center'}}, global_text_tags)
 end
 
+function Arena:update_units_with_combat_data()
+  -- Update the saved units with combat data from the arena
+  for i, saved_unit in ipairs(self.units) do
+    -- Find the corresponding arena unit by character and position
+    for j, arena_unit in ipairs(self.starting_units) do
+      if arena_unit.character == saved_unit.character and j == i then
+        -- Copy combat data from arena unit to saved unit
+        saved_unit.last_round_dps = arena_unit.total_damage_dealt / math.max(self.time_elapsed, 1)
+        saved_unit.last_round_damage = arena_unit.total_damage_dealt or 0
+        saved_unit.last_round_kills = arena_unit.kills or 0
+        saved_unit.last_round_survived = not arena_unit.dead
+        saved_unit.last_round_time_alive = arena_unit.time_alive or self.time_elapsed
+        break
+      end
+    end
+  end
+end
+
 
 --beat level (win)
 function Arena:transition()
@@ -779,6 +797,8 @@ function Arena:transition()
   ui_transition2:play{pitch = random:float(0.95, 1.05), volume = 0.5}
   TransitionEffect{group = main.transitions, x = gw/2, y = gh/2, color = state.dark_transitions and bg[-2] or self.color, transition_action = function(t)
 
+    -- Update units with combat data before transitioning
+    self:update_units_with_combat_data()
 
     Reset_Global_Proc_List()
     slow_amount = 1

--- a/arena.lua
+++ b/arena.lua
@@ -773,17 +773,13 @@ function Arena:set_timer_text()
 end
 
 function Arena:update_units_with_combat_data()
-  -- Update the saved units with combat data from the arena
+  -- Update the saved units with combat data from teams
   for i, saved_unit in ipairs(self.units) do
-    -- Find the corresponding arena unit by character and position
-    for j, arena_unit in ipairs(self.starting_units) do
-      if arena_unit.character == saved_unit.character and j == i then
-        -- Copy combat data from arena unit to saved unit
-        saved_unit.last_round_dps = arena_unit.total_damage_dealt / math.max(self.time_elapsed, 1)
-        saved_unit.last_round_damage = arena_unit.total_damage_dealt or 0
-        saved_unit.last_round_kills = arena_unit.kills or 0
-        saved_unit.last_round_survived = not arena_unit.dead
-        saved_unit.last_round_time_alive = arena_unit.time_alive or self.time_elapsed
+    -- Find the corresponding team by character and position
+    for j, team in ipairs(Helper.Unit.teams) do
+      if team.unit.character == saved_unit.character and j == i then
+        -- Save combat data from team to saved unit
+        team:save_combat_data_to_unit()
         break
       end
     end

--- a/enemies/enemy.lua
+++ b/enemies/enemy.lua
@@ -391,9 +391,12 @@ function Enemy:hit(damage, from, damageType, makesSound, cannotProcOnHit)
   if self.hp > self.max_hp then self.hp = self.max_hp end
   main.current.damage_dealt = main.current.damage_dealt + actual_damage
   
-  -- Track damage dealt by the attacker
-  if from and from.total_damage_dealt then
-    from.total_damage_dealt = from.total_damage_dealt + actual_damage
+  -- Track damage dealt by the attacker (for teams)
+  if from and from.team then
+    local attacker_team = Helper.Unit.teams[from.team]
+    if attacker_team then
+      attacker_team:record_damage(actual_damage)
+    end
   end
 
   --callbacks
@@ -410,9 +413,12 @@ function Enemy:hit(damage, from, damageType, makesSound, cannotProcOnHit)
     end
     self:onDeathCallbacks(from)
     
-    -- Track kill for the attacker
-    if from and from.kills then
-      from.kills = from.kills + 1
+    -- Track kill for the attacker (for teams)
+    if from and from.team then
+      local attacker_team = Helper.Unit.teams[from.team]
+      if attacker_team then
+        attacker_team:record_kill()
+      end
     end
 
     self:die()

--- a/enemies/enemy.lua
+++ b/enemies/enemy.lua
@@ -390,6 +390,11 @@ function Enemy:hit(damage, from, damageType, makesSound, cannotProcOnHit)
   self.hp = self.hp - actual_damage
   if self.hp > self.max_hp then self.hp = self.max_hp end
   main.current.damage_dealt = main.current.damage_dealt + actual_damage
+  
+  -- Track damage dealt by the attacker
+  if from and from.total_damage_dealt then
+    from.total_damage_dealt = from.total_damage_dealt + actual_damage
+  end
 
   --callbacks
   if from and from.onHitCallbacks and not cannotProcOnHit then
@@ -404,6 +409,11 @@ function Enemy:hit(damage, from, damageType, makesSound, cannotProcOnHit)
       from:onKillCallbacks(self, overkill)
     end
     self:onDeathCallbacks(from)
+    
+    -- Track kill for the attacker
+    if from and from.kills then
+      from.kills = from.kills + 1
+    end
 
     self:die()
     for i = 1, random:int(2, 3) do 

--- a/enemies/enemy_critter.lua
+++ b/enemies/enemy_critter.lua
@@ -82,9 +82,12 @@ function EnemyCritter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
   self.hp = self.hp - damage
   self:show_damage_number(damage, damageType)
   
-  -- Track damage dealt by the attacker
-  if from and from.total_damage_dealt then
-    from.total_damage_dealt = from.total_damage_dealt + damage
+  -- Track damage dealt by the attacker (for teams)
+  if from and from.team then
+    local attacker_team = Helper.Unit.teams[from.team]
+    if attacker_team then
+      attacker_team:record_damage(damage)
+    end
   end
 
   if from and from.onHitCallbacks and not cannotProcOnHit then
@@ -99,9 +102,12 @@ function EnemyCritter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
     end
     self:onDeathCallbacks(from)
     
-    -- Track kill for the attacker
-    if from and from.kills then
-      from.kills = from.kills + 1
+    -- Track kill for the attacker (for teams)
+    if from and from.team then
+      local attacker_team = Helper.Unit.teams[from.team]
+      if attacker_team then
+        attacker_team:record_kill()
+      end
     end
     
     self:die() 

--- a/enemies/enemy_critter.lua
+++ b/enemies/enemy_critter.lua
@@ -66,7 +66,7 @@ end
 function EnemyCritter:attack()
   if self.target and not self.target.dead then
     swordsman1:play{pitch = random:float(0.9, 1.1), volume = 0.5}
-    self.target:hit(self.dmg, self)
+    self.target:hit(self.dmg, self, nil, true, false)
   end
 end
 
@@ -81,6 +81,11 @@ function EnemyCritter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
 
   self.hp = self.hp - damage
   self:show_damage_number(damage, damageType)
+  
+  -- Track damage dealt by the attacker
+  if from and from.total_damage_dealt then
+    from.total_damage_dealt = from.total_damage_dealt + damage
+  end
 
   if from and from.onHitCallbacks and not cannotProcOnHit then
     from:onHitCallbacks(self, damage, damageType)
@@ -93,6 +98,12 @@ function EnemyCritter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
       from:onKillCallbacks(self, overkill)
     end
     self:onDeathCallbacks(from)
+    
+    -- Track kill for the attacker
+    if from and from.kills then
+      from.kills = from.kills + 1
+    end
+    
     self:die() 
   end
 end

--- a/helper/helper_spell.lua
+++ b/helper/helper_spell.lua
@@ -283,7 +283,7 @@ function Helper.Spell:damage_points()
         for j, point_damage in ipairs(unit.point_damages) do
             if not is_in_list(counted_damage_source_unit, point_damage.damage_source_unit) then
                 table.insert(counted_damage_source_unit, point_damage.damage_source_unit)
-                unit:hit(point_damage.damage, point_damage.damage_source_unit)
+                unit:hit(point_damage.damage, point_damage.damage_source_unit, nil, true, false)
             end
             local x = point_damage.point.unit.x + point_damage.point.x
             local y = point_damage.point.unit.y + point_damage.point.y

--- a/helper/spells/flame.lua
+++ b/helper/spells/flame.lua
@@ -65,7 +65,7 @@ function Helper.Spell.Flame:damage()
         for _, target in ipairs(Helper.Unit:get_list(not flame.unit.is_troop)) do
             if Helper.Geometry:is_inside_triangle(target.x, target.y, Helper.Geometry:get_triangle_from_height_and_width(flame.unit.x, flame.unit.y, flame.unit.x + flame.directionx, flame.unit.y + flame.directiony, flame.flameheight, flame.flamewidth)) 
             and Helper.Geometry:distance(flame.unit.x, flame.unit.y, target.x, target.y) < flame.flameheight then
-                target:hit(flame.damage, flame.unit)
+                target:hit(flame.damage, flame.unit, nil, true, false)
                 HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}
                 --for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = blue[0]} end
                 --for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = target.color} end

--- a/helper/spells/safety_dance.lua
+++ b/helper/spells/safety_dance.lua
@@ -122,7 +122,7 @@ function Helper.Spell.SafetyDance:hit(spell)
         targets = main.current.main:get_objects_in_shape(rect, main.current.friendlies)
     end
     for _, target in ipairs(targets) do
-        target:hit(spell.damage, spell.unit)
+        target:hit(spell.damage, spell.unit, nil, true, false)
         table.insert(spell.targets_hit, target)
 
         HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}

--- a/helper/spells/sweep.lua
+++ b/helper/spells/sweep.lua
@@ -93,7 +93,7 @@ function Helper.Spell.Sweep:update()
                                                                                                                     Helper.window_width + width*2 - Helper.Spell.Sweep.sweep_speed * t, Helper.Spell.Sweep.list[i].y2) then
                     target.damage_taken_at['sweep'] = Helper.Time.time
 
-                    target:hit(Helper.Spell.Sweep.list[i].damage)
+                    target:hit(Helper.Spell.Sweep.list[i].damage, nil, nil, true, false)
                     HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}
                     for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = blue[0]} end
                     for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = target.color} end
@@ -106,7 +106,7 @@ function Helper.Spell.Sweep:update()
                                                                                                                     width*4/5 + Helper.Spell.Sweep.sweep_speed * t, Helper.Spell.Sweep.list[i].y2) then
                     target.damage_taken_at['sweep'] = Helper.Time.time
 
-                    target:hit(Helper.Spell.Sweep.list[i].damage)
+                    target:hit(Helper.Spell.Sweep.list[i].damage, nil, nil, true, false)
                     HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}
                     for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = blue[0]} end
                     for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = target.color} end

--- a/helper/spells/v2/area_spell.lua
+++ b/helper/spells/v2/area_spell.lua
@@ -90,7 +90,7 @@ function Area_Spell:apply_damage()
         -- Only damage targets we haven't already hit in this spell's lifetime
         if not self.targets_hit_map[target.id] then
             if self.damage > 0 then
-                target:hit(self.damage, self.unit, self.damage_type)
+                target:hit(self.damage, self.unit, self.damage_type, true, false)
                 self:apply_hit_effect(target)
               end
               

--- a/helper/spells/v2/breathe_fire.lua
+++ b/helper/spells/v2/breathe_fire.lua
@@ -111,7 +111,7 @@ function Breathe_Fire:deal_damage()
   for _, target in ipairs(Helper.Unit:get_list(not self.unit.is_troop)) do
     if Helper.Geometry:is_inside_triangle(target.x, target.y, Helper.Geometry:get_triangle_from_height_and_width(self.unit.x, self.unit.y, self.unit.x + self.directionx, self.unit.y + self.directiony, self.flameheight, self.flamewidth))
       and Helper.Geometry:distance(self.unit.x, self.unit.y, target.x, target.y) < self.flameheight then
-      target:hit(self.damage, self.unit)
+      target:hit(self.damage, self.unit, nil, true, false)
       --HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}
     end
   end

--- a/helper/spells/v2/chain_spell.lua
+++ b/helper/spells/v2/chain_spell.lua
@@ -167,7 +167,7 @@ function ChainLightning:init(args)
     -- on_hit: This function is called on each target in the chain.
     on_hit = function(spell, target)
       -- 'spell' is the ChainLightning instance. 'self' would also work here.
-      target:hit(self.damage, nil, self.damageType, false)
+      target:hit(self.damage, nil, self.damageType, false, true)
     end,
 
     -- on_bounce: This function creates the visual and audio effects between targets.

--- a/helper/spells/v2/cleave.lua
+++ b/helper/spells/v2/cleave.lua
@@ -61,7 +61,7 @@ function Cleave:apply_effects()
       -- Check if the target is within the current cone radius and angle
       if Helper.Geometry:is_angle_between(angle_to_target, angle_start, angle_end) and distance_to_target <= current_radius then
         -- Target is inside the current cone, apply effects!
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, nil, true, false)
         target:push(self.knockback_force, angle_to_target, nil, self.knockback_duration)
         
         -- Mark as affected to avoid hitting again
@@ -102,7 +102,7 @@ end
 
 function Cleave:update(dt)
   if self.dead then return end
-  
+
   self:update_game_object(dt) 
   self.time_elapsed = self.time_elapsed + dt
   

--- a/helper/spells/v2/firewall_angled.lua
+++ b/helper/spells/v2/firewall_angled.lua
@@ -198,7 +198,7 @@ function EnemyFirewall:on_hit(unit)
 
     table.insert(self.hit_units, unit)
     
-    unit:hit(self.damage, self.unit)
+    unit:hit(self.damage, self.unit, nil, true, true)
     
     player_hit1:play{pitch = random:float(0.95, 1.05), volume = 1.2}
     

--- a/helper/spells/v2/instants.lua
+++ b/helper/spells/v2/instants.lua
@@ -65,7 +65,7 @@ function Arrow:update(dt)
 
   if math.distance(self.x, self.y, self.target.x, self.target.y) < 10 then
     hit2:play{volume=0.5}
-    self.target:hit(self.damage, self.unit)
+    self.target:hit(self.damage, self.unit, nil, true, false)
     self:die()
   end
 end
@@ -201,7 +201,7 @@ function DamageArc:try_damage()
 
   for _, target in ipairs(targets) do
     dot1:play{pitch = random:float(0.95, 1.05), volume = 0.7}
-    target:hit(self.damage, self.unit)
+    target:hit(self.damage, self.unit, nil, true, true)
     table.insert(self.targets_hit, target)
 
   end
@@ -343,7 +343,7 @@ function Boomerang:check_hits()
   local friendlies = main.current.main:get_objects_in_shape(self.shape, main.current.friendlies)
   for _, friendly in ipairs(friendlies) do
     if not table.contains(self.already_damaged, friendly) then
-      friendly:hit(self.damage, self.unit)
+      friendly:hit(self.damage, self.unit, nil, true, true)
       table.insert(self.already_damaged, friendly)
     end
   end
@@ -616,7 +616,7 @@ end
 function BurstBullet:check_hits()
   local friendlies = main.current.main:get_objects_in_shape(self.shape, main.current.friendlies)
   if #friendlies > 0 then
-    friendlies[1]:hit(self.damage, self.unit)
+    friendlies[1]:hit(self.damage, self.unit, nil, true, true)
     self:die()
   end
 end
@@ -692,7 +692,7 @@ function FireWall:try_damage(unit)
     
     unit:push(knockback_force, push_angle, nil, knockback_duration)
 
-    unit:hit(self.damage, self.unit)
+    unit:hit(self.damage, self.unit, nil, true, true)
     
     return true
   else
@@ -1087,7 +1087,7 @@ function LightningBall:find_and_shock_targets()
         end
 
         -- Shock the target
-        target:hit(self.damage, nil, DAMAGE_TYPE_LIGHTNING, false) -- Assuming units have an apply_shock method
+        target:hit(self.damage, nil, DAMAGE_TYPE_LIGHTNING, false, true) -- Assuming units have an apply_shock method
 
         -- Create the lightning visual effect
         LightningLine{

--- a/helper/spells/v2/safety_dancev2.lua
+++ b/helper/spells/v2/safety_dancev2.lua
@@ -95,7 +95,7 @@ function SafetyDanceSpell:apply_damage()
         for _, unit in ipairs(units_in_zone) do
             -- Ensure we only hit each unit once per damage tick
             if not self.targets_hit_this_tick[unit] then
-                unit:hit(self.damage, self.unit)
+                unit:hit(self.damage, self.unit, nil, true, true)
                 self.targets_hit_this_tick[unit] = true
 
                 -- Visual/Audio feedback for the hit

--- a/helper/spells/v2/stomp_spell.lua
+++ b/helper/spells/v2/stomp_spell.lua
@@ -42,7 +42,7 @@ function Stomp_Spell:die()
   end
   if #targets > 0 then self.spring:pull(0.05, 200, 10) end
   for _, target in ipairs(targets) do
-    target:hit(self.damage, self.unit)
+    target:hit(self.damage, self.unit, nil, true, false)
     if self.knockback then
       target:push(LAUNCH_PUSH_FORCE_BOSS, self.unit:angle_to_object(target))
     else

--- a/main.lua
+++ b/main.lua
@@ -820,24 +820,66 @@ function init()
     return info_text
   end
 
-  build_character_text = function(unit)
-    local item_stats = get_unit_stats(unit)
-    local buffs = get_unit_buffs(unit)
-
+  build_round_stats_text = function(unit)
     local text_lines = {}
-    local next_line = { text = '', font = pixul_font, alignment = 'center' }
-    for k, v in pairs(item_stats) do
-      next_line = { text = '', font = pixul_font, alignment = 'center' }
-      next_line.text = '[yellow[0]]+' .. (v * 100) .. '% ' .. k:capitalize()
-      table.insert(text_lines, next_line)
+    
+    -- Format damage and DPS
+    local damage_text = math.floor(unit.last_round_damage)
+    local dps_text = string.format("%.1f", unit.last_round_dps)
+    
+    -- Add damage line
+    table.insert(text_lines, { 
+      text = '[red]DMG: [red]' .. damage_text, 
+      font = pixul_font, 
+      alignment = 'center' 
+    })
+    
+    -- Add DPS line
+    table.insert(text_lines, { 
+      text = '[green]DPS: [green]' .. dps_text, 
+      font = pixul_font, 
+      alignment = 'center' 
+    })
+    
+    -- Add kills if available
+    if unit.last_round_kills and unit.last_round_kills > 0 then
+      table.insert(text_lines, { 
+        text = '[yellow]Kills: [yellow]' .. unit.last_round_kills, 
+        font = pixul_font, 
+        alignment = 'center' 
+      })
     end
-
+    
     local text2 = Text2 { group = main.current.ui, x = 0, y = 0,
       lines = text_lines, font = pixul_font, alignment = 'center',
       force_update = false }
-
-
+    
     return text2
+  end
+
+  build_character_text = function(unit)
+    -- Check if unit has combat data from previous round
+    if unit.last_round_dps and unit.last_round_damage then
+      return build_round_stats_text(unit)
+    else
+      -- Fall back to item stats if no combat data
+      local item_stats = get_unit_stats(unit)
+      local buffs = get_unit_buffs(unit)
+
+      local text_lines = {}
+      local next_line = { text = '', font = pixul_font, alignment = 'center' }
+      for k, v in pairs(item_stats) do
+        next_line = { text = '', font = pixul_font, alignment = 'center' }
+        next_line.text = '[yellow[0]]+' .. (v * 100) .. '% ' .. k:capitalize()
+        table.insert(text_lines, next_line)
+      end
+
+      local text2 = Text2 { group = main.current.ui, x = 0, y = 0,
+        lines = text_lines, font = pixul_font, alignment = 'center',
+        force_update = false }
+
+      return text2
+    end
   end
 
   local ylb1 = function(lvl)

--- a/miscellaneous_objects.lua
+++ b/miscellaneous_objects.lua
@@ -77,7 +77,7 @@ function Area:try_damage()
     for _, target in ipairs(targets) do
       if self:can_hit_with_effect(target, 'rooted') then
         target:root(self.rootDuration, self.unit)
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, self.damage_type, true, true)
         self:apply_hit_effect(target)
       end
     end
@@ -86,7 +86,7 @@ function Area:try_damage()
     for _, target in ipairs(targets) do
       if self:can_hit_with_effect(target, 'shocked') then
         target:shock(self.shockDuration, self.unit)
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, self.damage_type, true, true)
         self:apply_hit_effect(target)
       end
     end
@@ -99,7 +99,7 @@ function Area:try_damage()
       if self:can_hit_with_effect(target, 'stunned') then
         if math.random() < stun_chance then
           target:stun()
-          target:hit(self.damage, self.unit)
+          target:hit(self.damage, self.unit, self.damage_type, true, true)
           self:apply_hit_effect(target)
         end
       end
@@ -109,7 +109,7 @@ function Area:try_damage()
     for _, target in ipairs(targets) do
       if self:can_hit_with_effect(target, 'chilled') then
         target:chill(self.damage, self.unit)
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, self.damage_type, true, true)
         self:apply_hit_effect(target)
       end
     end
@@ -122,7 +122,7 @@ function Area:try_damage()
   elseif self.knockback_force then
     for _, target in ipairs(targets) do
       if self:can_hit_with_knockback(target) then
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, self.damage_type, true, true)
         target:push(self.knockback_force, self.unit:angle_to_object(target), nil, self.knockback_duration)
         self:apply_hit_effect(target)
       end
@@ -133,7 +133,7 @@ function Area:try_damage()
     end
   elseif self.damage > 0 then
     for _, target in ipairs(targets) do
-      target:hit(self.damage, self.unit, self.damage_type)
+      target:hit(self.damage, self.unit, self.damage_type, true, true)
       self:apply_hit_effect(target)
     end
   end
@@ -242,7 +242,7 @@ function DotArea:init(args)
         targets = main.current.main:get_objects_in_shape(self.shape, main.current.enemies)
       end
       for _, target in ipairs(targets) do
-        target:hit(self.damage/5)
+        target:hit(self.damage/5, self.parent, self.damage_type, true, true)
         for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = self.color} end
         for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = target.color} end
       end
@@ -253,7 +253,7 @@ function DotArea:init(args)
     local enemies = main.current.main:get_objects_in_shape(self.shape, main.current.enemies)
     if #enemies > 0 then self.spring:pull(0.05, 200, 10) end
     for _, enemy in ipairs(enemies) do
-      enemy:hit(self.damage/5, self.parent)
+      enemy:hit(self.damage/5, self.parent, self.damage_type, true, true)
       enemy:slow(0.8, 1, nil)
       HitCircle{group = main.current.effects, x = enemy.x, y = enemy.y, rs = 6, color = fg[0], duration = 0.1}
       for i = 1, 1 do HitParticle{group = main.current.effects, x = enemy.x, y = enemy.y, color = self.color} end
@@ -384,7 +384,7 @@ function ForceArea:init(args)
         elementor1:play{pitch = random:float(0.9, 1.1), volume = 0.5}
         local enemies = main.current.main:get_objects_in_shape(self.shape, main.current.enemies)
         for _, enemy in ipairs(enemies) do
-          enemy:hit(4*self.parent.dmg)
+          enemy:hit(4*self.parent.dmg, self.parent, self.damage_type, true, true)
           enemy:push(50*(self.knockback_m or 1), self:angle_to_object(enemy))
         end
       end
@@ -700,7 +700,7 @@ function Stomp:stomp()
         else
             target:slow(0.3, 1, nil)
         end
-        target:hit(self.damage, self.unit)
+        target:hit(self.damage, self.unit, self.damage_type, true, false)
         HitCircle{group = main.current.effects, x = target.x, y = target.y, rs = 6, color = fg[0], duration = 0.1}
         for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = self.color} end
         for i = 1, 1 do HitParticle{group = main.current.effects, x = target.x, y = target.y, color = target.color} end
@@ -850,7 +850,7 @@ function Laser:try_damage()
   local target_classes = self.damage_troops and main.current.friendlies or main.current.enemies
   local targets = main.current.main:get_objects_in_shape(self.shape, target_classes)
   for _, target in ipairs(targets) do
-    target:hit(self.dps * self.tick, self.parent)
+    target:hit(self.dps * self.tick, self.parent, self.damage_type, true, true)
   end
 
 end
@@ -1261,7 +1261,7 @@ end
 function Critter:attack()
   if self.target and not self.target.dead then
     swordsman1:play{pitch = random:float(0.9, 1.1), volume = 0.5}
-    self.target:hit(self.dmg, self, self.dmg_type)
+    self.target:hit(self.dmg, self, self.dmg_type, true, false)
   end
 end
 
@@ -1280,6 +1280,11 @@ function Critter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
   self.hp = self.hp - damage
 
   self:show_damage_number(damage, damageType)
+  
+  -- Track damage dealt by the attacker
+  if from and from.total_damage_dealt then
+    from.total_damage_dealt = from.total_damage_dealt + damage
+  end
 
   --on hit callbacks
   if from and from.onHitCallbacks and not cannotProcOnHit then
@@ -1293,6 +1298,12 @@ function Critter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
       from:onKillCallbacks(self, overkill)
     end
     self:onDeathCallbacks(from)
+    
+    -- Track kill for the attacker
+    if from and from.kills then
+      from.kills = from.kills + 1
+    end
+    
     self:die()
   end
 end
@@ -1366,7 +1377,7 @@ function Critter:on_collision_enter(other, contact)
       dmg = 20
     end
     self:push(push_force, self:angle_to_object(other) + math.pi, nil, duration)
-    self:hit(dmg, other, nil, false)
+    self:hit(dmg, other, nil, true, false)
   end
 end
 

--- a/miscellaneous_objects.lua
+++ b/miscellaneous_objects.lua
@@ -1281,9 +1281,12 @@ function Critter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
 
   self:show_damage_number(damage, damageType)
   
-  -- Track damage dealt by the attacker
-  if from and from.total_damage_dealt then
-    from.total_damage_dealt = from.total_damage_dealt + damage
+  -- Track damage dealt by the attacker (for teams)
+  if from and from.team then
+    local attacker_team = Helper.Unit.teams[from.team]
+    if attacker_team then
+      attacker_team:record_damage(damage)
+    end
   end
 
   --on hit callbacks
@@ -1299,9 +1302,12 @@ function Critter:hit(damage, from, damageType, makesSound, cannotProcOnHit)
     end
     self:onDeathCallbacks(from)
     
-    -- Track kill for the attacker
-    if from and from.kills then
-      from.kills = from.kills + 1
+    -- Track kill for the attacker (for teams)
+    if from and from.team then
+      local attacker_team = Helper.Unit.teams[from.team]
+      if attacker_team then
+        attacker_team:record_kill()
+      end
     end
     
     self:die()

--- a/objects.lua
+++ b/objects.lua
@@ -161,6 +161,11 @@ function Unit:init_unit()
   --chill system
   self.freeze_gauge = 0
   
+  -- Combat tracking
+  self.total_damage_dealt = 0
+  self.kills = 0
+  self.time_alive = 0
+  
   Helper.Unit:set_state(self, unit_states['normal'])
 end
 
@@ -299,8 +304,14 @@ function Unit:init_hitbox_points()
   end
 end
 
-
-
+function Unit:update(dt)
+  self:update_game_object(dt)
+  
+  -- Track time alive
+  if not self.dead then
+    self.time_alive = self.time_alive + dt
+  end
+end
 
 function Unit:bounce(nx, ny)
   local vx, vy = self:get_velocity()
@@ -561,7 +572,7 @@ function Unit:update_buffs(dt)
           
           -- 2. Deal the damage
           if damage_this_tick > 0 then
-              self:hit(damage_this_tick, nil, DAMAGE_TYPE_BURN, false)
+              self:hit(damage_this_tick, nil, DAMAGE_TYPE_BURN, false, true)
           end
 
           v.total_damage = v.total_damage - damage_this_tick

--- a/objects.lua
+++ b/objects.lua
@@ -572,7 +572,7 @@ function Unit:update_buffs(dt)
           
           -- 2. Deal the damage
           if damage_this_tick > 0 then
-              self:hit(damage_this_tick, nil, DAMAGE_TYPE_BURN, false, true)
+              self:hit(damage_this_tick, v.from, DAMAGE_TYPE_BURN, false, true)
           end
 
           v.total_damage = v.total_damage - damage_this_tick
@@ -1009,6 +1009,7 @@ function Unit:burn(damage, from)
   
   if existing_buff then
     -- Add damage to existing burn buff
+    existing_buff.from = from
     existing_buff.total_damage = existing_buff.total_damage + damage
     existing_buff.peak_damage = math.max(existing_buff.peak_damage, existing_buff.total_damage)
 
@@ -1017,6 +1018,7 @@ function Unit:burn(damage, from)
     -- Create new burn buff
     local burnBuff = {
       name = 'burn',
+      from = from,
       total_damage = damage, 
       peak_damage = damage,
       nextTick = 1.0, -- Tick every second
@@ -1071,6 +1073,7 @@ function Unit:burn_explode(from)
   if not self.buffs['burn'] then return end
 
   local peak_damage = self.buffs['burn'].peak_damage
+  local from = self.buffs['burn'].from
   self:remove_buff('burn')
   
   -- Calculate explosion damage based on max HP
@@ -1087,6 +1090,7 @@ function Unit:burn_explode(from)
   Knockback_Area_Spell{
     group = main.current.effects,
     is_troop = true,
+    unit = from,
     x = self.x,
     y = self.y,
     radius = explosion_radius,

--- a/procs/procs.lua
+++ b/procs/procs.lua
@@ -725,9 +725,10 @@ end
 
 function Proc_Lightning:onHit(target, damage)
   Proc_Lightning.super.onHit(self, target, damage)
-  
   local lightning_damage = damage * self.percent_damage_as_lightning
-  target:hit(lightning_damage, nil, self.damageType, false, true)
+  
+  print('lightning proc', self.unit, target, damage, lightning_damage)
+  target:hit(lightning_damage, self.unit, self.damageType, false, true)
 end
 
 Proc_Overcharge = Proc:extend()
@@ -1233,7 +1234,7 @@ function Proc_Radiance:onTick(dt)
         enemy:add_buff({name = 'radianceburn', damage = self.damage, duration = 1})
         
         --Helper.Sound:play_radiance()
-        enemy:hit(self.damage, nil, self.damageType, false, true)
+        enemy:hit(self.damage, self.unit, self.damageType, false, true)
       end
     end
   end
@@ -1328,7 +1329,8 @@ function Proc_Fire:onHit(target, damage)
   Proc_Fire.super.onHit(self, target, damage)
   --need to add a burn debuff to the Target
   local burn_damage = damage * self.percent_damage_as_burn
-  target:hit(burn_damage, nil, DAMAGE_TYPE_FIRE, false, true)
+  print('fire proc', self.unit, target, burn_damage)
+  target:hit(burn_damage, self.unit, DAMAGE_TYPE_FIRE, false, true)
 end
 
 Proc_Volcano = Proc:extend()
@@ -1603,7 +1605,7 @@ function Proc_Frost:onHit(target, damage)
   Proc_Frost.super.onHit(self, target, damage)
 
   local chill_damage = damage * self.percent_damage_as_chill
-  target:hit(chill_damage, nil, DAMAGE_TYPE_COLD, false, true)
+  target:hit(chill_damage, self.unit, DAMAGE_TYPE_COLD, false, true)
 end
 
 Proc_Frostfield = Proc:extend()

--- a/procs/procs.lua
+++ b/procs/procs.lua
@@ -187,7 +187,7 @@ function Proc_Craggy:onGotHit(from, damage)
     
     if from and from.hp and from.hp > 0 then
       from:stun()
-      from:hit(self.damage, self.unit)
+      from:hit(self.damage, self.unit, DAMAGE_TYPE_PHYSICAL, true, false)
     end
   end
 end
@@ -316,7 +316,7 @@ function Proc_Bash:onHit(target, damage)
     arrow_hit_wall2:play{pitch = random:float(0.8, 1.2), volume = 0.9}
 
     target:stun()
-    target:hit(self.damage, self.unit)
+    target:hit(self.damage, self.unit, DAMAGE_TYPE_PHYSICAL, false, true)
   end
 end
 
@@ -727,7 +727,7 @@ function Proc_Lightning:onHit(target, damage)
   Proc_Lightning.super.onHit(self, target, damage)
   
   local lightning_damage = damage * self.percent_damage_as_lightning
-  target:hit(lightning_damage, nil, self.damageType, false)
+  target:hit(lightning_damage, nil, self.damageType, false, true)
 end
 
 Proc_Overcharge = Proc:extend()
@@ -1233,7 +1233,7 @@ function Proc_Radiance:onTick(dt)
         enemy:add_buff({name = 'radianceburn', damage = self.damage, duration = 1})
         
         --Helper.Sound:play_radiance()
-        enemy:hit(self.damage, nil, self.damageType)
+        enemy:hit(self.damage, nil, self.damageType, false, true)
       end
     end
   end
@@ -1328,7 +1328,7 @@ function Proc_Fire:onHit(target, damage)
   Proc_Fire.super.onHit(self, target, damage)
   --need to add a burn debuff to the Target
   local burn_damage = damage * self.percent_damage_as_burn
-  target:hit(burn_damage, nil, DAMAGE_TYPE_FIRE, false)
+  target:hit(burn_damage, nil, DAMAGE_TYPE_FIRE, false, true)
 end
 
 Proc_Volcano = Proc:extend()
@@ -1603,7 +1603,7 @@ function Proc_Frost:onHit(target, damage)
   Proc_Frost.super.onHit(self, target, damage)
 
   local chill_damage = damage * self.percent_damage_as_chill
-  target:hit(chill_damage, nil, DAMAGE_TYPE_COLD, false)
+  target:hit(chill_damage, nil, DAMAGE_TYPE_COLD, false, true)
 end
 
 Proc_Frostfield = Proc:extend()

--- a/procs/procs.lua
+++ b/procs/procs.lua
@@ -725,10 +725,9 @@ end
 
 function Proc_Lightning:onHit(target, damage)
   Proc_Lightning.super.onHit(self, target, damage)
-  local lightning_damage = damage * self.percent_damage_as_lightning
   
-  print('lightning proc', self.unit, target, damage, lightning_damage)
-  target:hit(lightning_damage, self.unit, self.damageType, false, true)
+  local lightning_damage = damage * self.percent_damage_as_lightning
+  target:hit(lightning_damage, nil, self.damageType, false, true)
 end
 
 Proc_Overcharge = Proc:extend()
@@ -1234,7 +1233,7 @@ function Proc_Radiance:onTick(dt)
         enemy:add_buff({name = 'radianceburn', damage = self.damage, duration = 1})
         
         --Helper.Sound:play_radiance()
-        enemy:hit(self.damage, self.unit, self.damageType, false, true)
+        enemy:hit(self.damage, nil, self.damageType, false, true)
       end
     end
   end
@@ -1329,7 +1328,6 @@ function Proc_Fire:onHit(target, damage)
   Proc_Fire.super.onHit(self, target, damage)
   --need to add a burn debuff to the Target
   local burn_damage = damage * self.percent_damage_as_burn
-  print('fire proc', self.unit, target, burn_damage)
   target:hit(burn_damage, self.unit, DAMAGE_TYPE_FIRE, false, true)
 end
 
@@ -1577,7 +1575,7 @@ function Proc_Phoenix:onDeath()
         group = main.current.effects,
         x = location.x, y = location.y,
         pick_shape = 'circle',
-        dmg = 0,
+        damage = 0,
         r = 6, duration = 0.4, color = self.color,
         is_troop = self.unit.is_troop,
         unit = troop,
@@ -1652,7 +1650,7 @@ function Proc_Frostfield:onHit(target, damage)
         x= target.x, y = target.y,
         pick_shape = 'circle',
         damage_ticks = true,
-        dmg = 0,
+        damage = 0,
         r = self.radius, duration = self.duration, color = self.color,
         is_troop = self.unit.is_troop,
         chillAmount = self.chill_amount,
@@ -1715,7 +1713,7 @@ function Proc_Frostnova:init(args)
     Proc_Frostnova.super.init(self, args)
 
     -- Define the proc's properties from data
-    self.damage = (self.data.damage or 20) * (self.data.damageMulti or 1)
+    self.damage = (self.data.damage or 10) * (self.data.damageMulti or 1)
     self.damageType = self.data.damageType or DAMAGE_TYPE_COLD
     self.radius_boost = self.data.radius_boost or 3
     self.radius = self.data.radius or 45
@@ -1807,7 +1805,7 @@ function Proc_Frostnova:create_proc_display_area()
         r = 0, -- Start with a radius of 0
         duration = self.procDelay, -- Give it a lifetime just longer than the wind-up
         color = self.color,
-        dmg = 0,
+        damage = 0,
     }
 end
 
@@ -1842,13 +1840,12 @@ function Proc_Frostnova:cast()
         unit = self.unit,
         x = self.unit.x, y = self.unit.y,
         pick_shape = 'circle',
-        dmg = self.damage,
+        damage = self.damage,
+        damage_type = self.damageType,
         r = self.radius + self.radius_boost, 
         duration = self.duration, 
         color = self.color,
         is_troop = self.unit.is_troop,
-        chillAmount = self.chillAmount,
-        chillDuration = self.chillDuration,
     }
 end
 
@@ -1884,7 +1881,7 @@ function Proc_Firenova:explode(target, damage)
     unit = self.unit,
     x = target.x, y = target.y,
     pick_shape = 'circle',
-    dmg = self.damage,
+    damage = self.damage,
     r = self.radius, duration = self.duration, color = self.color,
     is_troop = self.unit.is_troop,
     knockback_force = self.knockback_force,
@@ -1954,7 +1951,7 @@ function Proc_Shatterlance:explode(target, damage)
     group = main.current.effects,
     x = target.x, y = target.y,
     pick_shape = 'circle',
-    dmg = damage,
+    damage = damage,
     r = self.radius, color = self.color,
     is_troop = self.unit.is_troop,
     damage_type = self.damageType,
@@ -1989,7 +1986,7 @@ function Proc_Glacialprison:onKill(target)
       x = target.x, y = target.y,
       unit = self.unit,
       pick_shape = 'circle',  
-      dmg = self.damage,
+      damage = self.damage,
       r = self.radius, duration = self.duration, color = self.color,
       damage_ticks = true,
       tick_rate = self.tick_rate,

--- a/ui/character_card.lua
+++ b/ui/character_card.lua
@@ -90,10 +90,10 @@ function CharacterCard:createButtons()
   -- Create "Last Round" button
   self.last_round_button = Button{
     group = main.current.ui,
-    x = self.x - 25,
+    x = self.x,
     y = self.y - self.h/2 + 30,
-    w = 40,
-    h = 20,
+    w = 60,
+    h = 18,
     bg_color = 'bg',
     fg_color = 'bg10',
     button_text = 'Last Round',
@@ -103,10 +103,10 @@ function CharacterCard:createButtons()
   -- Create "Unit Stats" button
   self.unit_stats_button = Button{
     group = main.current.ui,
-    x = self.x + 25,
-    y = self.y - self.h/2 + 30,
-    w = 40,
-    h = 20,
+    x = self.x,
+    y = self.y - self.h/2 + 55,
+    w = 60,
+    h = 18,
     bg_color = 'bg',
     fg_color = 'bg10',
     button_text = 'Unit Stats',

--- a/units/player/player_troop.lua
+++ b/units/player/player_troop.lua
@@ -480,9 +480,12 @@ function Troop:hit(damage, from, damageType, makesSound, cannotProcOnHit)
 
   self:show_damage_number(damage, damageType)
   
-  -- Track damage dealt by the attacker
-  if from and from.total_damage_dealt then
-    from.total_damage_dealt = from.total_damage_dealt + actual_damage
+  -- Track damage dealt by the attacker (for teams)
+  if from and from.team then
+    local attacker_team = Helper.Unit.teams[from.team]
+    if attacker_team then
+      attacker_team:record_damage(actual_damage)
+    end
   end
   
   --on hit callbacks
@@ -511,9 +514,12 @@ function Troop:hit(damage, from, damageType, makesSound, cannotProcOnHit)
     end
     self:onDeathCallbacks(from)
     
-    -- Track kill for the attacker
-    if from and from.kills then
-      from.kills = from.kills + 1
+    -- Track kill for the attacker (for teams)
+    if from and from.team then
+      local attacker_team = Helper.Unit.teams[from.team]
+      if attacker_team then
+        attacker_team:record_kill()
+      end
     end
 
     self:die()

--- a/units/player/player_troop.lua
+++ b/units/player/player_troop.lua
@@ -480,6 +480,11 @@ function Troop:hit(damage, from, damageType, makesSound, cannotProcOnHit)
 
   self:show_damage_number(damage, damageType)
   
+  -- Track damage dealt by the attacker
+  if from and from.total_damage_dealt then
+    from.total_damage_dealt = from.total_damage_dealt + actual_damage
+  end
+  
   --on hit callbacks
   if from and from.onHitCallbacks and not cannotProcOnHit then
     from:onHitCallbacks(self, actual_damage, damageType)
@@ -505,6 +510,11 @@ function Troop:hit(damage, from, damageType, makesSound, cannotProcOnHit)
       from:onKillCallbacks(self, overkill)
     end
     self:onDeathCallbacks(from)
+    
+    -- Track kill for the attacker
+    if from and from.kills then
+      from.kills = from.kills + 1
+    end
 
     self:die()
 
@@ -553,7 +563,7 @@ function Troop:on_collision_enter(other, contact)
     end
     
     self:push(push_force, self:angle_to_object(other) + math.pi, nil, duration)
-    self:hit(dmg, other, nil, false)
+    self:hit(dmg, other, nil, false, true)
   elseif table.any(main.current.friendlies, function(v) return other:is(v) end) then
       -- Handle knockback propagation
       if self.state == unit_states['knockback'] and other.state ~= unit_states['knockback'] then

--- a/units/units.lua
+++ b/units/units.lua
@@ -255,7 +255,7 @@ end
 
 function Team:damage_all_troops(damage, from, damageType)
   for i, troop in ipairs(self.troops) do
-    troop:hit(damage, from, damageType)
+    troop:hit(damage, from, damageType, true, false)
   end
 end
 

--- a/units/units.lua
+++ b/units/units.lua
@@ -40,6 +40,13 @@ function Team:init(i, unit)
   self.index = i
   self.unit = unit
   self.color = character_colors[unit.character]
+  
+  -- Combat tracking
+  self.total_damage_dealt = 0
+  self.kills = 0
+  self.round_start_time = love.timer.getTime()
+  self.round_end_time = nil
+  self.data_saved_to_unit = false
 end
 
 function Team:set_troop_data(data)
@@ -51,6 +58,7 @@ function Team:add_troop(x, y)
   self.troop_data.y = y
   local troop = Create_Troop(self.troop_data)
   troop.team = self.index
+  troop.created_at = love.timer.getTime()
   table.insert(self.troops, troop)
   
   return troop
@@ -309,12 +317,79 @@ function Team:add_proc(proc)
 end
 
 function Team:die()
+  -- Save combat data to unit before dying
+  self:save_combat_data_to_unit()
+  
   for i, troop in ipairs(self.troops) do
     troop:die()
+    if not troop.died_at then
+      troop.died_at = love.timer.getTime()
+    end
   end
   for i, proc in ipairs(self.procs) do
     proc:die()
   end
+end
+
+function Team:record_damage(damage)
+  self.total_damage_dealt = self.total_damage_dealt + damage
+end
+
+function Team:record_kill()
+  self.kills = self.kills + 1
+end
+
+function Team:save_combat_data_to_unit()
+  if self.data_saved_to_unit then return end
+  
+  self.round_end_time = love.timer.getTime()
+  
+  -- Calculate duration from round start until last troop dies or end of round
+  local last_troop_death_time = self.round_start_time
+  for _, troop in ipairs(self.troops) do
+    if troop.died_at and troop.died_at > last_troop_death_time then
+      last_troop_death_time = troop.died_at
+    end
+  end
+  
+  -- Use the later of last troop death or round end
+  local effective_end_time = math.max(last_troop_death_time, self.round_end_time)
+  local round_duration = effective_end_time - self.round_start_time
+  
+  -- Calculate DPS over the effective round duration
+  local dps = round_duration > 0 and (self.total_damage_dealt / round_duration) or 0
+  
+  -- Save data to the unit
+  self.unit.last_round_dps = dps
+  self.unit.last_round_damage = self.total_damage_dealt
+  self.unit.last_round_kills = self.kills
+  self.unit.last_round_survived = #self.troops > 0 and not self.all_troops_dead
+  self.unit.last_round_time_alive = round_duration
+  
+  self.data_saved_to_unit = true
+end
+
+function Team:check_all_troops_dead()
+  local all_dead = true
+  for i, troop in ipairs(self.troops) do
+    if not troop.dead then
+      all_dead = false
+      break
+    end
+  end
+  
+  if all_dead and not self.all_troops_dead then
+    self.all_troops_dead = true
+    -- Don't save data here, wait for arena transition
+    -- But also don't destroy the team - keep it alive for data collection
+  end
+  
+  return all_dead
+end
+
+function Team:should_destroy()
+  -- Only destroy the team if we've already saved the data
+  return self.data_saved_to_unit
 end
 
 -- character = name of unit (on buy screen)
@@ -338,3 +413,5 @@ function Create_Troop(args)
     return Troop(args)
   end
 end
+
+


### PR DESCRIPTION
- add dps and total dmg trackers to troops, display in buy screen, attribute all onHit effects to their source, and prevent them from retriggering onHit