### PR TITLE
Unit stretch while moving

### DIFF
--- a/engine/game/hitfx.lua
+++ b/engine/game/hitfx.lua
@@ -48,6 +48,11 @@ function HitFX:use(name, x, k, d, flash_duration)
   self.parent.springs[name]:pull(x, k, d)
 end
 
+function HitFX:animate(name, ...)
+  if not self.parent then return end
+  self.parent.springs[name]:animate(...)
+end
+
 
 function HitFX:pull(name, ...)
   self.parent.springs[name]:pull(...)

--- a/units/player/archer_troop.lua
+++ b/units/player/archer_troop.lua
@@ -18,6 +18,9 @@ function Archer_Troop:setup_cast()
     name = 'arrow',
     viable = function() return Helper.Spell:target_is_in_range(self, self.attack_sensor.rs, false) end,
     oncast = function() end,
+    oncastfinish = function() 
+      self:stretch_on_attack()
+    end,
     unit = self,
     target = self:my_target(),
     castcooldown = self.cooldownTime,

--- a/units/player/laser_troop.lua
+++ b/units/player/laser_troop.lua
@@ -47,6 +47,9 @@ function Laser_Troop:setup_cast()
     name = 'laser',
     viable = function() local target = self:get_random_object_in_shape(self.attack_sensor, main.current.enemies); return target end,
     oncast = function() end,
+    oncastfinish = function() 
+      self:stretch_on_attack()
+    end,
     castcooldown = self.cooldownTime,
     cast_length = 0,
     backswing = 0.1,

--- a/units/player/player_troop.lua
+++ b/units/player/player_troop.lua
@@ -19,9 +19,11 @@ function Troop:init(args)
   self:init_unit()
   local level = self.level or 1
 
-  -- Ensure you have separate springs for x and y scaling
-  self.hfx:add('scale_x', 1, 80, 12) -- stiffness=80, damping=20 are good for tuning
-  self.hfx:add('scale_y', 1, 80, 12)
+  self.hfx:add('move_scale_x', 1, 80, 20)
+  self.hfx:add('move_scale_y', 1, 80, 20)
+
+  self.hfx:add('attack_scale_x', 1, 50, 8) 
+  self.hfx:add('attack_scale_y', 1, 50, 8)
 
   -- This new variable will store the speed from the previous frame
   self.last_speed = 0
@@ -36,6 +38,14 @@ function Troop:init(args)
   self:set_character()
 
   Helper.Unit:set_state(self, unit_states['normal'])
+end
+
+
+--called in oncastfinish for all troops
+function Troop:stretch_on_attack()
+  local stretch_factor = 0.4
+  self.hfx:pull('attack_scale_y', stretch_factor)
+  self.hfx:pull('attack_scale_x', - stretch_factor)
 end
 
 function Troop:follow_mouse()
@@ -90,8 +100,8 @@ function Troop:update_movement_effect(dt)
   end
   
   -- Animate the springs toward their new targets
-  self.hfx:animate('scale_x', target_scale_x)
-  self.hfx:animate('scale_y', target_scale_y)
+  self.hfx:animate('move_scale_x', target_scale_x)
+  self.hfx:animate('move_scale_y', target_scale_y)
   
   -- Finally, update last_speed for the next frame's calculation
   self.last_speed = speed
@@ -300,7 +310,11 @@ end
 
 function Troop:draw()
   --graphics.circle(self.x, self.y, self.attack_sensor.rs, orange[0], 1)
-  graphics.push(self.x, self.y, self.r, self.hfx.scale_x.x, self.hfx.scale_y.x)
+
+  local final_scale_x = self.hfx.attack_scale_x.x * self.hfx.move_scale_x.x * self.hfx.hit.x
+  local final_scale_y = self.hfx.attack_scale_y.x * self.hfx.move_scale_y.x * self.hfx.hit.x
+
+  graphics.push(self.x, self.y, self.r, final_scale_x, final_scale_y)
   self:draw_buffs()
 
   -- darken the non-selected units

--- a/units/player/swordsman_troop.lua
+++ b/units/player/swordsman_troop.lua
@@ -48,6 +48,9 @@ function Swordsman_Troop:setup_cast()
     name = 'attack',
     viable = function() return Helper.Spell:target_is_in_range(self, self.attack_sensor.rs, false) end,
     oncast = function() end,
+    oncastfinish = function() 
+      self:stretch_on_attack()
+    end,
     unit = self,
     target = self:my_target(),
     castcooldown = self.cooldownTime,


### PR DESCRIPTION
added stretch when troops attack and move
modified cooldown timer effect to be less sudden, and sized correctly for the new stretch
fixed spawnmanager bug where boss dying wasn't ending round