### PR TITLE
Add 4 specials, dynamic spawn cadence, and debug arena

### DIFF
--- a/animations/animations.lua
+++ b/animations/animations.lua
@@ -928,6 +928,12 @@ enemy_type_to_size = {
   ['hunter_swarmer'] = 'swarmer',
   ['tank'] = 'block',
 
+  -- Custom specials added alongside the L1-L11 cleanup. See enemies/regular/*.
+  ['splitter'] = 'special',
+  ['pulse_walker'] = 'special',
+  ['drone_carrier'] = 'special',
+  ['linker'] = 'special',
+
   -- Minibosses
   ['bigstomper'] = 'huge',
   

--- a/combat_stats/combat_stats.lua
+++ b/combat_stats/combat_stats.lua
@@ -57,7 +57,11 @@ enemy_attack_cooldowns = {
   -- Mortar's heavy lob is hard to dodge when it spams; +1.5s on top of
   -- 'fast' (1.1s) gives the player a real beat between shells.
   ['mortar'] = attack_cooldowns['fast'] + 1.5,
-  ['arcspread'] = attack_cooldowns['medium'],
+  -- Arcspread fires a 4-arc fan that blankets a wide area; at the old
+  -- 'medium' (1.5s) cadence it was overtuned — near-constant pressure with
+  -- little room to dodge between volleys. Pushed well past 'very-slow' to
+  -- ~5s so each fan reads as a discrete, dodgeable event.
+  ['arcspread'] = attack_cooldowns['very-slow'] + 1.0,
   ['cleaver'] = attack_cooldowns['slow'],
   ['charger'] = attack_cooldowns['slow'],
   ['summoner'] = attack_cooldowns['slow'],
@@ -469,18 +473,27 @@ function POST_BOSS_HP_MULT(level)
   return 1
 end
 
+-- ENEMY_SCALE_BY_LEVEL only defines entries 1..25 but enemies can spawn at
+-- higher logical levels (e.g. the debug arena lives at DEBUG_LEVEL_NUMBER).
+-- Clamp to the highest defined scale so the SCALED_* helpers never multiply
+-- by nil. ENEMY_LEVEL_SCALING already does this defensively; do the same
+-- here.
+local function _scale_for(level)
+  return ENEMY_SCALE_BY_LEVEL[level] or ENEMY_SCALE_BY_LEVEL[#ENEMY_SCALE_BY_LEVEL] or 0
+end
+
 SCALED_ENEMY_HP = function(level, base_hp)
-  local scale = ENEMY_SCALE_BY_LEVEL[level]
+  local scale = _scale_for(level)
   return (base_hp + (base_hp * 0.2 * scale)) * POST_BOSS_HP_MULT(level)
 end
 
 SCALED_ENEMY_DAMAGE = function(level, base_dmg)
-  local scale = ENEMY_SCALE_BY_LEVEL[level]
+  local scale = _scale_for(level)
   return base_dmg + (base_dmg * 0.1 * scale)
 end
 
 SCALED_ENEMY_MS = function(level, base_ms)
-  local scale = ENEMY_SCALE_BY_LEVEL[level]
+  local scale = _scale_for(level)
   return base_ms + (base_ms * 0.03 * scale)
 end
 

--- a/enemies/enemy_includes.lua
+++ b/enemies/enemy_includes.lua
@@ -41,6 +41,10 @@ require 'enemies/regular/swarmer'
 require 'enemies/regular/hunter_swarmer'
 require 'enemies/regular/slime'
 require 'enemies/regular/tank'
+require 'enemies/regular/splitter'
+require 'enemies/regular/pulse_walker'
+require 'enemies/regular/drone_carrier'
+require 'enemies/regular/linker'
 
 require 'enemies/miniboss/bigstomper'
 

--- a/enemies/regular/drone_carrier.lua
+++ b/enemies/regular/drone_carrier.lua
@@ -1,0 +1,196 @@
+-- Drone Carrier: drifts around the arena and periodically deploys 1-2
+-- short-lived homing drones that seek the nearest troop. Distinct from
+-- spawner (which spawns persistent critters) and turret (which fires
+-- straight projectiles) — drones home with a limited turn rate, so they
+-- feel like a soft area-denial threat rather than a sniper bullet.
+
+-- ============================================================================
+-- HomingDrone: a slow seeking projectile with limited turn rate and a fixed
+-- lifetime. Hits a troop on contact, then pops. Coded after SlimeBullet
+-- (slime.lua) but with target tracking instead of straight-line travel.
+-- ============================================================================
+HomingDrone = Object:extend()
+HomingDrone.__class_name = 'HomingDrone'
+HomingDrone:implement(GameObject)
+HomingDrone:implement(Physics)
+function HomingDrone:init(args)
+  self:init_game_object(args)
+  self.radius = self.radius or 3.5
+  self.shape = Circle(self.x, self.y, self.radius)
+
+  self.color = (self.color or blue[5]):clone()
+  self.color.a = 0.95
+
+  self.damage = get_dmg_value(self.damage)
+
+  self.speed = self.speed or 80
+  -- Lifetime instead of max-distance — homing path length is unpredictable.
+  self.lifetime = self.lifetime or 4
+  self.turn_rate = self.turn_rate or 2.4 -- radians/sec; slow enough to dodge
+
+  -- Initial heading: toward the target if we have one, else random.
+  if self.target and self.target.x and self.target.y then
+    self.r = math.atan2(self.target.y - self.y, self.target.x - self.x)
+  else
+    self.r = self.r or random:float(0, 2 * math.pi)
+  end
+  self:set_angle(self.r)
+end
+
+function HomingDrone:update(dt)
+  self:update_game_object(dt)
+
+  -- Re-pick target if ours died — keeps the drone useful through the run.
+  -- Helper.Target:get_closest_enemy filters by fully_onscreen which troops
+  -- never set (see helper_target.lua), so use get_random_enemy instead.
+  if (not self.target or self.target.dead) and self.unit and not self.unit.dead then
+    self.target = Helper.Target:get_random_enemy(self.unit)
+  end
+
+  -- Turn toward target with a capped rate so the player can sidestep.
+  if self.target and not self.target.dead then
+    local desired = math.atan2(self.target.y - self.y, self.target.x - self.x)
+    local diff = desired - self.r
+    while diff > math.pi do diff = diff - 2 * math.pi end
+    while diff < -math.pi do diff = diff + 2 * math.pi end
+    local max_step = self.turn_rate * dt
+    if diff > max_step then diff = max_step
+    elseif diff < -max_step then diff = -max_step end
+    self.r = self.r + diff
+  end
+
+  self.x = self.x + self.speed * math.cos(self.r) * dt
+  self.y = self.y + self.speed * math.sin(self.r) * dt
+  self.shape:move_to(self.x, self.y)
+
+  self.lifetime = self.lifetime - dt
+  if self.lifetime <= 0 then self:die() end
+  if self.x < -10 or self.x > gw + 10 or self.y < -10 or self.y > gh + 10 then
+    self:die()
+  end
+
+  self:check_hits()
+end
+
+function HomingDrone:check_hits()
+  local friendlies = main.current.main:get_objects_in_shape(self.shape, main.current.friendlies)
+  if #friendlies > 0 then
+    local t = friendlies[1]
+    t:hit(self.damage, self.unit, nil, true, true)
+    if t.push and not t.dead then
+      t:push(LAUNCH_PUSH_FORCE_ENEMY, self.r, nil, KNOCKBACK_DURATION_ENEMY)
+    end
+    self:die()
+  end
+end
+
+function HomingDrone:draw()
+  graphics.push(self.x, self.y, self.r)
+  graphics.circle(self.x, self.y, self.shape.rs, self.color)
+  -- Small trail tail for "drone" feel.
+  local tail = self.color:clone()
+  tail.a = 0.4
+  graphics.circle(self.x - math.cos(self.r) * 4, self.y - math.sin(self.r) * 4, self.shape.rs * 0.6, tail)
+  graphics.pop()
+end
+
+function HomingDrone:die()
+  if self.dead then return end
+  self.dead = true
+end
+
+
+-- ============================================================================
+-- DroneDeploy: spawns 2 HomingDrones from the carrier's current location,
+-- one per side, so the deploy reads as a "release" not a single shot.
+-- ============================================================================
+DroneDeploy = Object:extend()
+DroneDeploy.__class_name = 'DroneDeploy'
+DroneDeploy:implement(GameObject)
+function DroneDeploy:init(args)
+  self:init_game_object(args)
+  local n = args.count or 2
+  for i = 1, n do
+    local side_angle = (i - 1) * (2 * math.pi / n) + random:float(-0.2, 0.2)
+    local ox, oy = math.cos(side_angle) * 6, math.sin(side_angle) * 6
+    HomingDrone{
+      group = self.group,
+      x = self.x + ox,
+      y = self.y + oy,
+      target = self.target,
+      damage = self.damage,
+      unit = self.unit,
+      speed = 80,
+      lifetime = 4,
+    }
+  end
+  if scout1 then
+    scout1:play{pitch = random:float(1.05, 1.2), volume = 0.5}
+  end
+  self.dead = true
+end
+
+function DroneDeploy:update(dt) end
+function DroneDeploy:draw() end
+
+
+-- ============================================================================
+-- Drone Carrier enemy
+-- ============================================================================
+local fns = {}
+
+fns['init_enemy'] = function(self)
+  self.data = self.data or {}
+  self.icon = 'goblin'
+
+  self.color = blue[5]:clone()
+  Set_Enemy_Shape(self, self.size)
+
+  self.class = 'special_enemy'
+
+  -- Keeps a steady pace while deploying; bumping it out of position is fine
+  -- (unlike sniper/pulse_walker) because drones use the target at fire time.
+  self.baseIdleTimer = 0.4
+  self.baseActionTimer = 2.5
+  self.move_option_weight = 0.6
+  self.stopChasingInRange = true
+
+  -- Long sensor — the carrier doesn't need to be close; the drones close
+  -- the distance. 450 covers most of the arena.
+  self.attack_range = 450
+  self.attack_sensor = Circle(self.x, self.y, self.attack_range)
+
+  self.attack_options = {}
+
+  local deploy = {
+    name = 'deploy_drones',
+    viable = function() return Helper.Target:get_random_enemy(self) end,
+    oncast = function() self.target = Helper.Target:get_random_enemy(self) end,
+    cancel_on_range = false,
+    instantspell = true,
+    cast_sound = scout1,
+    spellclass = DroneDeploy,
+    spelldata = {
+      group = main.current.main,
+      damage = function() return self.dmg * 0.7 end,
+      count = 2,
+      unit = self,
+    },
+  }
+  table.insert(self.attack_options, deploy)
+end
+
+fns['draw_enemy'] = function(self)
+  local animation_success = self:draw_animation()
+  if not animation_success then
+    self:draw_fallback_animation()
+  end
+
+  -- Cast ring during deploy windup, similar to roach but in blue.
+  if self.state == unit_states['casting'] and self.castObject then
+    local pct = self.castObject:get_cast_percentage() or 0
+    graphics.circle(self.x, self.y, 4 + pct * 6, blue[5], 1)
+  end
+end
+
+enemy_to_class['drone_carrier'] = fns

--- a/enemies/regular/linker.lua
+++ b/enemies/regular/linker.lua
@@ -1,0 +1,121 @@
+-- Linker: spawns in pairs (group_size = 2 in the spawn config) with a
+-- damaging beam tether between them. The two linkers drift independently,
+-- so the beam swings around the arena — troops standing on the line take
+-- periodic damage. When one linker dies the tether breaks and the partner
+-- becomes a harmless drifter. Walker shell follows brute/tank; pair-up
+-- logic runs once on the first frame; tether-damage and beam-draw run
+-- every tick.
+
+local fns = {}
+
+LINKER_BEAM_WIDTH = 6
+LINKER_TICK_RATE = 0.18
+LINKER_DAMAGE_FRAC = 0.35
+
+-- Standalone helper: minimum distance from point P to segment AB. Used
+-- per-tick to decide which troops are standing on the beam.
+local function point_to_segment_distance(px, py, ax, ay, bx, by)
+  local abx, aby = bx - ax, by - ay
+  local apx, apy = px - ax, py - ay
+  local ab_len2 = abx * abx + aby * aby
+  local t
+  if ab_len2 > 0 then
+    t = (apx * abx + apy * aby) / ab_len2
+    if t < 0 then t = 0 elseif t > 1 then t = 1 end
+  else
+    t = 0
+  end
+  local cx, cy = ax + t * abx, ay + t * aby
+  local dx, dy = px - cx, py - cy
+  return math.sqrt(dx * dx + dy * dy)
+end
+
+fns['init_enemy'] = function(self)
+  self.data = self.data or {}
+  self.icon = 'sniper'
+
+  self.color = blue[5]:clone()
+  Set_Enemy_Shape(self, self.size)
+
+  self.class = 'special_enemy'
+
+  -- Beam holds its position more cleanly if linkers don't get shoved into
+  -- each other on every hit.
+  self.knockback_resistance = self.knockback_resistance or 0.6
+
+  -- No attacks of its own; the threat is the tether to its partner.
+  self.attack_options = {}
+
+  self.baseIdleTimer = 0.3
+  self.baseActionTimer = 2
+  self.move_option_weight = 0.5
+  self.stopChasingInRange = false
+
+  self.linker_pair = nil
+
+  -- Pair up on the next frame. Both linkers from the same spawn group land
+  -- in the arena in the same frame; deferring by 0.1s guarantees both
+  -- exist before the search runs. First linker to wake up grabs the first
+  -- unpaired partner it finds.
+  self.t:after(0.1, function()
+    if self.dead or self.linker_pair then return end
+    local enemies = main.current.main:get_objects_by_classes(main.current.enemies)
+    for _, e in ipairs(enemies) do
+      if e ~= self and e.type == 'linker' and not e.dead and not e.linker_pair then
+        self.linker_pair = e
+        e.linker_pair = self
+        break
+      end
+    end
+  end)
+
+  -- Beam tick: scan troops along the segment between self and pair and
+  -- damage any within LINKER_BEAM_WIDTH. Only one linker of the pair runs
+  -- the tick — gated by id ordering so we don't double up the damage.
+  self.t:every(LINKER_TICK_RATE, function()
+    if self.dead then return end
+    local p = self.linker_pair
+    if not p or p.dead then return end
+    -- Deterministic owner: only the linker with the lower id ticks damage.
+    if self.id and p.id and self.id > p.id then return end
+
+    local troops = main.current.main:get_objects_by_classes(main.current.friendlies)
+    for _, troop in ipairs(troops) do
+      if troop and not troop.dead then
+        local d = point_to_segment_distance(troop.x, troop.y, self.x, self.y, p.x, p.y)
+        if d < LINKER_BEAM_WIDTH then
+          troop:hit(self.dmg * LINKER_DAMAGE_FRAC, self, nil, true, true)
+        end
+      end
+    end
+  end, nil, nil, 'linker_beam_tick')
+
+  -- Sever the tether on death so the partner stops drawing/ticking a beam
+  -- to a corpse. The partner stays alive but defangs to a melee body.
+  self.state_change_functions['death'] = function(self)
+    if self.linker_pair and not self.linker_pair.dead then
+      self.linker_pair.linker_pair = nil
+    end
+    self.linker_pair = nil
+  end
+end
+
+fns['draw_enemy'] = function(self)
+  local animation_success = self:draw_animation()
+  if not animation_success then
+    self:draw_fallback_animation()
+  end
+
+  -- Beam render: only one linker of the pair draws it. Use the same
+  -- id-ordering as the damage tick so the draw lines up with the hit zone.
+  local p = self.linker_pair
+  if p and not p.dead and self.id and p.id and self.id <= p.id then
+    local beam_color = blue[5]:clone()
+    graphics.line(self.x, self.y, p.x, p.y, beam_color, LINKER_BEAM_WIDTH)
+    -- Inner bright line so the beam reads as "active" rather than decorative.
+    local inner = blue[0]:clone()
+    graphics.line(self.x, self.y, p.x, p.y, inner, 1)
+  end
+end
+
+enemy_to_class['linker'] = fns

--- a/enemies/regular/pulse_walker.lua
+++ b/enemies/regular/pulse_walker.lua
@@ -1,0 +1,95 @@
+-- Pulse Walker: a slow melee approacher that periodically charges a
+-- self-centered circular AoE and unleashes it. Each pulse plays a 0.6s
+-- telegraph ring (Area at floor level, no damage) followed by the actual
+-- damage Area. Walker shell follows brute/tank; pulse pattern follows the
+-- bomb explosion + telegraph idea but on a recurring timer instead of a
+-- trigger.
+
+local fns = {}
+
+PULSE_WALKER_RADIUS = 55
+PULSE_WALKER_TELEGRAPH = 0.6
+PULSE_WALKER_INTERVAL = 3.2
+
+fns['init_enemy'] = function(self)
+  self.data = self.data or {}
+  self.icon = 'tank'
+
+  self.color = yellow[0]:clone()
+  Set_Enemy_Shape(self, self.size)
+
+  self.class = 'special_enemy'
+
+  -- Holds its line while charging; the pulse needs to read from the body's
+  -- current position so getting shoved mid-charge would dodge its own AoE.
+  self.knockback_immune = true
+
+  self.stopChasingInRange = false
+  self.haltOnPlayerContact = true
+
+  self.baseIdleTimer = 0.3
+  self.baseActionTimer = 1.5
+
+  -- No spell-driven attacks. The pulse runs on its own timer so it doesn't
+  -- compete with the chase logic in the action selector.
+  self.attack_options = {}
+
+  self.t:every(PULSE_WALKER_INTERVAL, function()
+    if self.dead then return end
+    self:pulse()
+  end, nil, nil, 'pulse_walker_pulse')
+end
+
+fns['pulse'] = function(self)
+  local telegraph_color = yellow[0]:clone()
+  telegraph_color.a = 0.4
+  -- Telegraph ring: zero-damage Area at floor level so it sits under the
+  -- enemy sprite and reads as a warning, not a hit.
+  Area{
+    group = main.current.floor,
+    unit = self,
+    follow_unit = true,
+    x = self.x,
+    y = self.y,
+    r = PULSE_WALKER_RADIUS,
+    pick_shape = 'circle',
+    duration = PULSE_WALKER_TELEGRAPH,
+    dmg = 0,
+    is_troop = false,
+    color = telegraph_color,
+  }
+
+  -- Audible windup so it's not silent during the telegraph.
+  if tick_new then
+    tick_new:play{pitch = random:float(0.85, 0.95), volume = 0.8}
+  end
+
+  self.t:after(PULSE_WALKER_TELEGRAPH, function()
+    if self.dead then return end
+    Area{
+      group = main.current.effects,
+      unit = self,
+      x = self.x,
+      y = self.y,
+      r = PULSE_WALKER_RADIUS,
+      pick_shape = 'circle',
+      duration = 0.18,
+      dmg = self.dmg * 0.9,
+      is_troop = false,
+      color = yellow[0]:clone(),
+    }
+    if explosion_new then
+      explosion_new:play{pitch = random:float(0.95, 1.05), volume = 0.7}
+    end
+    camera:shake(2, 0.15)
+  end)
+end
+
+fns['draw_enemy'] = function(self)
+  local animation_success = self:draw_animation()
+  if not animation_success then
+    self:draw_fallback_animation()
+  end
+end
+
+enemy_to_class['pulse_walker'] = fns

--- a/enemies/regular/sniper.lua
+++ b/enemies/regular/sniper.lua
@@ -74,7 +74,14 @@ fns['draw_enemy'] = function(self)
 
     local aim = self.locked_target or self.target
     if aim and (aim.dead == nil or not aim.dead) then
-      graphics.dashed_line(self.x, self.y, aim.x, aim.y, 4, 3, red[0], 1)
+      -- Extend the aim line past the target to the screen edge so the player
+      -- reads the full shot trajectory, not just sniper -> target. Project
+      -- along the aim angle a distance >= the screen diagonal.
+      local angle = math.atan2(aim.y - self.y, aim.x - self.x)
+      local reach = math.sqrt(gw * gw + gh * gh)
+      local end_x = self.x + math.cos(angle) * reach
+      local end_y = self.y + math.sin(angle) * reach
+      graphics.dashed_line(self.x, self.y, end_x, end_y, 4, 3, red[0], 1)
     end
   elseif self.locked_target then
     self.locked_target = nil

--- a/enemies/regular/splitter.lua
+++ b/enemies/regular/splitter.lua
@@ -1,0 +1,60 @@
+-- Splitter: a melee approacher with no attacks of its own. On death it
+-- bursts into 3 swarmers that fan out from its position. Forces the player
+-- to choose between killing it cleanly (and dealing with the splits) or
+-- ignoring it (and getting tagged by the body). Coded after brute.lua for
+-- the walker shell, with a death hook in the bomb.lua style for the burst.
+
+local fns = {}
+
+fns['init_enemy'] = function(self)
+  self.data = self.data or {}
+  self.icon = 'rat1'
+
+  self.color = green[0]:clone()
+  Set_Enemy_Shape(self, self.size)
+
+  self.stopChasingInRange = false
+  self.haltOnPlayerContact = true
+
+  self.class = 'special_enemy'
+  self.baseIdleTimer = 0
+
+  self.attack_sensor = Circle(self.x, self.y, 500)
+  self.move_option_weight = 0.4
+
+  -- No attacks; the threat is the body and the death burst.
+  self.attack_options = {}
+
+  self.split_count = self.split_count or 3
+
+  self.state_change_functions['death'] = function(self)
+    if self.already_split then return end
+    self.already_split = true
+    -- Stagger the spawns by a hair so they don't all share one frame's
+    -- physics tick (which can wedge them inside each other).
+    for i = 1, self.split_count do
+      local angle = (i - 1) * (2 * math.pi / self.split_count) + random:float(-0.3, 0.3)
+      local ox, oy = math.cos(angle) * 10, math.sin(angle) * 10
+      self.t:after(0.02 * i, function()
+        Enemy{
+          type = 'swarmer',
+          group = main.current.main,
+          x = self.x + ox,
+          y = self.y + oy,
+          path_heading = angle,
+          level = self.level,
+          data = {},
+        }
+      end)
+    end
+  end
+end
+
+fns['draw_enemy'] = function(self)
+  local animation_success = self:draw_animation()
+  if not animation_success then
+    self:draw_fallback_animation()
+  end
+end
+
+enemy_to_class['splitter'] = fns

--- a/game_constants.lua
+++ b/game_constants.lua
@@ -169,6 +169,19 @@ WAVE_KILL_QUOTA_MULTIPLIER = 1.5
 -- 0.2 = each spawn fires somewhere in [interval*0.8, interval*1.2].
 SPECIAL_SPAWN_JITTER = 0.2
 
+-- Dynamic special-spawn cadence (campaign levels). The first special of a
+-- level arrives SPECIAL_CADENCE_INITIAL seconds in. Each subsequent spawn is
+-- scheduled at the moment the current one fires: the delay to the next is
+-- SPECIAL_CADENCE_BASE + SPECIAL_CADENCE_INCREMENT * (cycle specials alive,
+-- counting the group just queued). So spawns space out as the field fills
+-- and tighten back up as the player clears it. Tanks (basic-pool filler) are
+-- excluded from the count. Example with base 5 / increment 3:
+--   t=5 first; +5+3*1=8 -> t=13; if still alive +5+3*2=11 -> t=24,
+--   but if the first died, +5+3*1=8 -> t=21.
+SPECIAL_CADENCE_INITIAL = 5
+SPECIAL_CADENCE_BASE = 5
+SPECIAL_CADENCE_INCREMENT = 3
+
 -- Seconds between swarmer clump spawns in the continuous system. Clump size
 -- itself is SWARMERS_PER_LEVEL(level), same as the old wave instructions.
 -- Tuned so clumps don't pile up faster than the field can drain through

--- a/main.lua
+++ b/main.lua
@@ -1473,6 +1473,12 @@ function init()
     ['summoner'] = 300,
     ['assassin'] = 300,
 
+    --custom specials (T2-ish power)
+    ['splitter'] = 200,
+    ['pulse_walker'] = 250,
+    ['drone_carrier'] = 250,
+    ['linker'] = 200,
+
     --bosses
     ['stompy'] = BOSS_ROUND_POWER,
     ['dragon'] = BOSS_ROUND_POWER,
@@ -1511,6 +1517,12 @@ function init()
     ['slowcharger'] = orange[3],
     ['turret'] = red[3],
     ['tank'] = red[3],
+
+    -- Custom specials
+    ['splitter'] = green[3],
+    ['pulse_walker'] = yellow[3],
+    ['drone_carrier'] = blue[3],
+    ['linker'] = blue[3],
   }
 
   DAMAGE_TYPE_TO_COLOR = {

--- a/mainmenu.lua
+++ b/mainmenu.lua
@@ -205,6 +205,19 @@ function MainMenu:on_enter(from)
     love.event.quit()
   end}
 
+  -- Debug entry point: starts a fresh run on the debug-arena level and
+  -- routes through the buy screen so the player can still pick units and
+  -- items before launching. Sits just below the quit button in the main
+  -- button column.
+  self.debug_button = Button{group = self.main_ui, x = 43, y = gh/2 + 100, force_update = true, button_text = 'debug', fg_color = 'bg10', bg_color = 'bg', action = function(b)
+    ui_transition2:play{pitch = random:float(0.95, 1.05), volume = 0.5}
+    ui_switch1:play{pitch = random:float(0.95, 1.05), volume = 0.5}
+    TransitionEffect{group = main.transitions, x = gw/2, y = gh/2, color = state.dark_transitions and bg[-2] or fg[0], transition_action = function()
+      self.transitioning = true
+      Start_Debug_Run_And_Go_To_Buy_Screen()
+    end, text = Text({{text = '[wavy, ' .. tostring(state.dark_transitions and 'fg' or 'bg') .. ']debug arena...', font = pixul_font, alignment = 'center'}}, global_text_tags)}
+  end}
+
   -- hide for now (achievement test button)
   -- self.unlock_button = Button{group = self.main_ui, x = 40, y = gh/2  + 100, force_update = true, button_text ='unlock', fg_color = 'bg10', bg_color='bg', action = function(b)
     

--- a/save_game.lua
+++ b/save_game.lua
@@ -40,7 +40,21 @@ function Start_New_Run_And_Go_To_Buy_Screen()
   -- Common logic to start a new run and transition to buy screen
   local new_run = Start_New_Run()
   Save_Run(new_run)
-  
+
+  Go_To_Buy_Screen()
+end
+
+-- Debug-only entry point: starts a fresh run with the debug arena as the
+-- current level, then routes through the normal buy screen so the player
+-- can pick units/items before launching. Reuses Start_New_Run() so all the
+-- per-run init (Clear_User_Stats, run_time reset, telemetry new-run-id)
+-- runs the same way as a normal new game — then patches level to the
+-- debug entry. Triggered by the "debug" main-menu button.
+function Start_Debug_Run_And_Go_To_Buy_Screen()
+  local new_run = Start_New_Run()
+  new_run.level = DEBUG_LEVEL_NUMBER
+  state.level = DEBUG_LEVEL_NUMBER
+  Save_Run(new_run)
   Go_To_Buy_Screen()
 end
 

--- a/spawns/levelmanager.lua
+++ b/spawns/levelmanager.lua
@@ -11,114 +11,114 @@ function Is_Boss_Level(level)
   end
 end
 
--- Continuous-spawn config per level. Each level picks a basic enemy that fills
--- the field on a steady clump cadence and one or more special pools that each
--- fire on their own jittered timer (skip-on-cap, not queued). LEVEL_SPAWN_POOLS
--- is indexed by level; non-boss levels beyond the table fall back to the
--- highest defined entry.
--- Every special-pool spawn waits 17s before its first fire so the player gets
--- a uniform breathing-room window at level start before specials begin
--- pressuring them.
-LEVEL_SPECIAL_FIRST_FIRE = 17
+-- Per-level spawn config. Each level has:
+--   basic        - the continuous swarmer clump filler (+ optional tank
+--                  substitution via replace_type/replace_every).
+--   special_pool - a flat list of special enemy types. The SpawnManager draws
+--                  one at random each time the dynamic cadence fires (see
+--                  SPECIAL_CADENCE_* in game_constants). Omit/empty for no
+--                  specials. Per-type group sizes are handled centrally by
+--                  Special_Cadence_Group_Size (roach in 2-3s, linker as a
+--                  tethered pair, everything else single).
+-- Boss levels are handled separately and have no entry here.
+-- (The legacy timer/`at`-event `specials` field is still honored by the
+-- SpawnManager and is used by the debug arena, but campaign levels use
+-- special_pool exclusively.)
 
--- Special-pool entries can be either:
---   {type, at = 0.3, group_size?}         - one-shot at this fraction of the
---                                            level's kill_quota progress
---   {type, interval, max_alive, ...}      - recurring timer-based pool
--- Mix freely. The basic pool is always timer-based (continuous filler).
-LEVEL_SPAWN_POOLS = {
-  [1] = {
-    basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
-    specials = {},
-  },
-  [2] = {
-    basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
-    specials = {
-      -- Timer-based pool: a slime arrives ~every 15s (jittered by
-      -- SPECIAL_SPAWN_JITTER), starting at the 10s mark, with at most 2 alive
-      -- on the field at once.
-      {type = 'slime', interval = 15, max_alive = 2, first_fire = 10},
-    },
-  },
-  [3] = {
-    basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
-    specials = {
-      {type = 'roach', at = 0.3, group_size = function() return random:int(2, 3) end},
-      {type = 'sniper', at = 0.55},
-      {type = 'roach', at = 0.8, group_size = function() return random:int(2, 3) end},
-    },
-  },
-  [4] = {
-    basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
-    specials = {
-      {type = 'brute', at = 0.2},
-      {type = 'orb', at = 0.45},
-      {type = 'brute', at = 0.7},
-      {type = 'orb', at = 0.9},
-    },
-  },
-  [5] = {
-    basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
-    specials = {
-      {type = 'cleaver', at = 0.15},
-      {type = 'snakearrow', at = 0.35},
-      {type = 'mortar', at = 0.55},
-      {type = 'cleaver', at = 0.75},
-      {type = 'snakearrow', at = 0.9},
-    },
-  },
-  -- 6 is stompy boss. Levels 7-10 (T2) are built below from a shared pool.
+-- Tier-2 draw pool (L7-L10, between stompy at L6 and dragon at L11). Wide and
+-- varied so the back third doesn't feel like recycled early levels; includes
+-- the four custom enemies.
+local T2_SPECIAL_POOL = {
+  'snakearrow', 'mortar', 'roach', 'cleaver', 'brute', 'orb', 'boomerang',
+  'sniper', 'plasma', 'slime',
+  'splitter', 'pulse_walker', 'drone_carrier', 'linker',
 }
 
--- T2 (between stompy at level 6 and dragon at level 11) draws its specials
--- from a fixed pool: snakearrow / mortar / slime / roach. Each level gets a
--- few picks from the pool with deterministic-per-level seeding so the same
--- level number always rolls the same mix (safe across save/load) but every
--- level feels different from its neighbors.
-local T2_SPECIAL_POOL = {'snakearrow', 'mortar', 'slime', 'roach'}
+-- Early-game pool. L2/L3 draw a random 2 of these per run; L4/L5 use all 3.
+local EARLY_SPECIAL_POOL = {'slime', 'roach', 'sniper'}
 
-local function build_t2_specials(level)
-  local rng = Random(level * 7919)
-  local fractions = {0.2, 0.5, 0.8}
-  local specials = {}
-  local slime_added = false
-  for _, frac in ipairs(fractions) do
-    local t = rng:table(T2_SPECIAL_POOL)
-    if t == 'slime' then
-      -- Slime is timer-based (recurring) like on level 2 — collapse multiple
-      -- slime rolls into a single pool so we don't double up.
-      if not slime_added then
-        table.insert(specials, {type = 'slime', interval = 15, max_alive = 2, first_fire = 10})
-        slime_added = true
-      end
-    else
-      local entry = {type = t, at = frac}
-      if t == 'roach' then
-        entry.group_size = function() return random:int(2, 3) end
-      end
-      table.insert(specials, entry)
-    end
+-- Pull n distinct entries from pool at random (no mutation of pool).
+local function pick_random_subset(pool, n)
+  local copy = {}
+  for _, v in ipairs(pool) do table.insert(copy, v) end
+  local result = {}
+  for _ = 1, math.min(n, #copy) do
+    table.insert(result, table.remove(copy, random:int(1, #copy)))
   end
-  return specials
+  return result
 end
+
+LEVEL_SPAWN_POOLS = {
+  [1] = {
+    -- Tanks now appear from level 1: every 5th basic clump is swapped for a
+    -- single tank, introducing the knockback-immune wall enemy immediately.
+    basic = {
+      type = 'swarmer',
+      interval = BASIC_CLUMP_INTERVAL,
+      replace_type = 'tank',
+      replace_every = 5,
+      replace_group_size = 1,
+    },
+    special_pool = {},
+  },
+  -- 2 and 3 are built per-run in get_spawn_config_for_level (random 2-of-3).
+  [4] = {
+    basic = {
+      type = 'swarmer',
+      interval = BASIC_CLUMP_INTERVAL,
+      replace_type = 'tank',
+      replace_every = 6,
+      replace_group_size = 1,
+    },
+    special_pool = {'slime', 'roach', 'sniper'},
+  },
+  [5] = {
+    basic = {
+      type = 'swarmer',
+      interval = BASIC_CLUMP_INTERVAL,
+      replace_type = 'tank',
+      replace_every = 6,
+      replace_group_size = 1,
+    },
+    special_pool = {'slime', 'roach', 'sniper'},
+  },
+  -- 6 is stompy boss. 7-10 (T2) are built below from the shared T2 pool.
+}
 
 for _, lvl in ipairs({7, 8, 9, 10}) do
   LEVEL_SPAWN_POOLS[lvl] = {
     basic = {
       type = 'swarmer',
       interval = BASIC_CLUMP_INTERVAL,
-      -- Every 4th basic tick, fire a single tank instead of a swarmer clump.
-      -- Tank is a tanky melee approacher with no attacks; mixed in to break
-      -- the swarmer cadence between stompy and dragon.
+      -- Every 4th basic tick fires a single tank instead of a swarmer clump.
       replace_type = 'tank',
       replace_every = 4,
       replace_group_size = 1,
     },
-    specials = build_t2_specials(lvl),
+    special_pool = T2_SPECIAL_POOL,
   }
 end
 
+-- Per-type spawn group size for the dynamic cadence. Each group member counts
+-- toward the cadence's "specials on screen" increment.
+function Special_Cadence_Group_Size(enemy_type)
+  if enemy_type == 'roach' then return random:int(2, 3) end
+  -- Linkers spawn as a tethered pair so the beam has two endpoints.
+  if enemy_type == 'linker' then return 2 end
+  return 1
+end
+
 local function get_spawn_config_for_level(level)
+  -- L2/L3: random 2-of-3 from the early pool, re-rolled each time the level
+  -- list is built (i.e. per run). Built fresh here so the randomization isn't
+  -- frozen at file-load time.
+  if level == 2 or level == 3 then
+    return {
+      basic = {type = 'swarmer', interval = BASIC_CLUMP_INTERVAL},
+      special_pool = pick_random_subset(EARLY_SPECIAL_POOL, 2),
+    }
+  end
+
   if LEVEL_SPAWN_POOLS[level] then return LEVEL_SPAWN_POOLS[level] end
   -- Pick the highest defined level <= this one as a fallback so later levels
   -- aren't empty if they haven't been authored yet.
@@ -129,11 +129,90 @@ local function get_spawn_config_for_level(level)
   return best or LEVEL_SPAWN_POOLS[1]
 end
 
+-- Debug arena: a non-shipping level for inspecting every special enemy in
+-- isolation. Reachable via the hidden "debug" button on the main menu. Each
+-- special arrives on its own timer pool with `interval` huge enough that it
+-- effectively fires once (max_alive = 1 prevents pile-up), staggered by
+-- DEBUG_SPAWN_STAGGER seconds so they walk on one at a time.
+DEBUG_LEVEL_NUMBER = 30
+DEBUG_SPAWN_STAGGER = 4
+
+local DEBUG_SPECIAL_TYPES = {
+  -- Roughly the order of appearance in the normal campaign, then the
+  -- unused-but-functional specials, then the four custom additions.
+  'slime', 'roach', 'sniper', 'brute', 'orb', 'cleaver', 'snakearrow', 'mortar',
+  'bomb', 'selfburst', 'burst', 'arcspread', 'aim_spread',
+  'singlemortar', 'line_mortar', 'boomerang', 'plasma',
+  'archer', 'goblin_archer', 'big_goblin_archer',
+  'firewall_caster', 'turret', 'shooter', 'spawner', 'tank',
+  -- Custom specials added in this pass:
+  'splitter', 'pulse_walker', 'drone_carrier', 'linker',
+}
+
+function Build_Debug_Level_Entry()
+  local specials = {}
+  local delay = DEBUG_SPAWN_STAGGER
+  local total_power = 0
+  for _, t in ipairs(DEBUG_SPECIAL_TYPES) do
+    local entry = {
+      type = t,
+      interval = 99999, -- effectively one-shot
+      max_alive = 1,
+      first_fire = delay,
+    }
+    local count = 1
+    if t == 'linker' then
+      -- Linkers pair up at spawn time; deploy two from this pool.
+      entry.group_size = 2
+      entry.max_alive = 2
+      count = 2
+    end
+    table.insert(specials, entry)
+
+    -- Tally the round_power this pool will contribute when its members die.
+    -- kill_quota = sum across all pools so the level only completes once the
+    -- player has actually cleared the field (instead of a hard-coded
+    -- infinite quota where it never ends).
+    total_power = total_power + (enemy_to_round_power[t] or 0) * count
+    if t == 'splitter' then
+      -- Splitter bursts into 3 swarmers on death — include their power so
+      -- the quota only completes after the splits are cleared too.
+      total_power = total_power + 3 * (enemy_to_round_power['swarmer'] or 0)
+    end
+
+    delay = delay + DEBUG_SPAWN_STAGGER
+  end
+
+  return {
+    level = DEBUG_LEVEL_NUMBER,
+    -- round_power is the divisor for gold-per-kill (each kill grants its
+    -- enemy_to_round_power as a fraction of this total). Match it to the
+    -- kill_quota so gold-per-kill curves like a normal level.
+    round_power = total_power,
+    color = grey[0],
+    environmental_hazards = {},
+    spawn_config = {
+      -- Specials-only — no basic swarmer pool so the arena stays uncluttered
+      -- and each enemy is easy to study in isolation.
+      specials = specials,
+    },
+    -- Quota = exact sum of every expected enemy's round_power, so the
+    -- progress bar fills naturally as the player clears the field and the
+    -- level only completes when the last expected enemy is dead.
+    kill_quota = total_power,
+    waves_power = {total_power},
+  }
+end
+
 function Build_Level_List(max_level)
   local level_list = {}
   for i = 1, max_level do
       level_list[i] = {level = i, round_power = 0, color = grey[0], environmental_hazards = {}}
   end
+  -- Inject the debug entry so WorldManager can index level_list[DEBUG_LEVEL_NUMBER]
+  -- when the run is started via Start_Debug_Run. Harmless for normal play (the
+  -- level_map only iterates 1..NUMBER_OF_ROUNDS).
+  level_list[DEBUG_LEVEL_NUMBER] = Build_Debug_Level_Entry()
 
   for i = 1, max_level do
     if Is_Boss_Level(i) then

--- a/spawns/spawnmanager.lua
+++ b/spawns/spawnmanager.lua
@@ -594,8 +594,18 @@ function SpawnManager:init_spawn_pools()
   self.special_pools = {}
   self.special_events = {}
 
+  -- Dynamic cadence state (campaign levels). nil pool = no cadence spawns.
+  self.special_pool = nil
+  self.special_cadence_next_fire = nil
+
   local config = self.level_data and self.level_data.spawn_config
   if not config then return end
+
+  -- New-style flat draw pool: the cadence picks one type at random each fire.
+  if config.special_pool and #config.special_pool > 0 then
+    self.special_pool = config.special_pool
+    self.special_cadence_next_fire = SPECIAL_CADENCE_INITIAL or 5
+  end
 
   if config.basic then
     self.basic_pool = {
@@ -864,6 +874,41 @@ function SpawnManager:tick_spawn_pools(dt)
           specials_capped = counts.specials >= (MAX_ALIVE_SPECIALS or 9999)
           ev.fired = true
         end
+      end
+    end
+  end
+
+  -- Dynamic cadence (campaign levels). Single global timer that draws one
+  -- random type from special_pool each fire. The delay to the NEXT fire is
+  -- computed here, at the moment of this fire: base + increment * (cycle
+  -- specials currently alive + the group just queued). Tanks come from the
+  -- basic pool and are excluded from the count.
+  if self.special_pool and self.special_cadence_next_fire then
+    self.special_cadence_next_fire = self.special_cadence_next_fire - dt
+    if self.special_cadence_next_fire <= 0 then
+      if not self:quota_met() and not specials_capped then
+        local enemy_type = random:table(self.special_pool)
+        local group_size = Special_Cadence_Group_Size(enemy_type)
+
+        self.wave_spawn_delay = 0
+        Spawn_Group_With_Location(self.arena,
+          {enemy_type, group_size, 'nil'},
+          Get_Offscreen_Spawn_Point())
+
+        -- Reflect the just-queued spawns in the running counts.
+        counts.specials = counts.specials + group_size
+        counts.by_type[enemy_type] = (counts.by_type[enemy_type] or 0) + group_size
+        specials_capped = counts.specials >= (MAX_ALIVE_SPECIALS or 9999)
+
+        -- Cycle specials alive = all specials minus tanks (basic-pool filler).
+        local cycle_alive = counts.specials - (counts.by_type['tank'] or 0)
+        local base = SPECIAL_CADENCE_BASE or 5
+        local inc = SPECIAL_CADENCE_INCREMENT or 3
+        self.special_cadence_next_fire = base + inc * math.max(cycle_alive, 0)
+      else
+        -- Quota met or field full: re-check soon without advancing the big
+        -- delay, so we resume the moment there's room.
+        self.special_cadence_next_fire = 1
       end
     end
   end


### PR DESCRIPTION
New enemies: splitter, pulse_walker, drone_carrier, linker (registered in includes, size/round-power/color tables).

Spawn system: replace fraction/interval special pools with a dynamic cadence (first at 5s, then base+inc*cycle-specials-alive, tanks excluded, groups kept). L1 gets tanks; L2/L3 draw random 2-of-[slime,roach,sniper]; L4/L5 use all 3; L7-10 draw from the wider T2 pool.

Debug arena (level 30) reachable from a main-menu button, routes through the buy screen, spawns one of each special on a stagger, and completes via a real kill_quota.

Sniper aim line now extends to the screen edge along the shot angle. arcspread cooldown raised from 1.5s to 5s.